### PR TITLE
Include QR code pointing to the download page

### DIFF
--- a/lib/assets/s3_android_html_template.erb
+++ b/lib/assets/s3_android_html_template.erb
@@ -48,6 +48,10 @@
         color: #737373;
         font-size: 14px;
       }
+      #qrcode {
+        width: 256px;
+        margin: 0 auto;
+      }
       #footnote {
         color: #737373;
         font-size: 14px;
@@ -78,6 +82,8 @@
 
     <h3 id="os-message">Please open this page on your Android device!</h3>
 
+    <div id="qrcode"></div>
+
     <p id="finished">
       App is being installed. You might have to close the browser.
     </p>
@@ -86,5 +92,10 @@
       This is a beta version and is not intended for public sharing.
     </p>
     <img src="https://fastlane.tools/assets/images/fastlane-logo-lockup.png" id="fastlaneLogo" />
+
+    <script src="/static/qrcode.min.js"></script>
+    <script>
+      new QRCode(document.getElementById("qrcode"), window.location.href);
+    </script>
   </body>
 </html>

--- a/lib/assets/s3_ios_html_template.erb
+++ b/lib/assets/s3_ios_html_template.erb
@@ -48,6 +48,10 @@
         color: #737373;
         font-size: 14px;
       }
+      #qrcode {
+        width: 256px;
+        margin: 0 auto;
+      }
       #footnote {
         color: #737373;
         font-size: 14px;
@@ -79,6 +83,8 @@
 
     <h3 id="os-message">Please open this page on your iOS device!</h3>
 
+    <div id="qrcode"></div>
+
     <p id="finished">
       App is being installed. Close Safari using the home button.
     </p>
@@ -87,5 +93,10 @@
       This is a beta version and is not intended for public sharing.
     </p>
     <img src="https://fastlane.tools/assets/images/fastlane-logo-lockup.png" id="fastlaneLogo" />
+
+    <script src="/static/qrcode.min.js"></script>
+    <script>
+      new QRCode(document.getElementById("qrcode"), window.location.href);
+    </script>
   </body>
 </html>


### PR DESCRIPTION
This lets you easily open the same download page on your phone when opening the download page on desktop.

I opted for just hosting the qrcode lib from
https://davidshimjs.github.io/qrcodejs/ in the same S3 bucket (it's about 20kb minified), to avoid having to upload a new copy of it with every app that we upload.